### PR TITLE
Declare library as public

### DIFF
--- a/influxdb/dune
+++ b/influxdb/dune
@@ -1,5 +1,6 @@
 (library
  (name influxdb)
+ (public_name influxdb)
   (inline_tests (flags (-show-counts)))
   (preprocess (pps ppx_expect))
   (libraries base stdio))


### PR DESCRIPTION
This will allow documentation to be generated for it

https://discuss.ocaml.org/t/help-with-dune-and-odoc/2706